### PR TITLE
Add support for client id postfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Add support for client id postfixes to allow multiple connections per token.
+- Add new config option `getClientIdPostfix` to customize the default.
+
 ## [0.1.0] - 2018-06-29
 ### Changed
 - Adapt new api url. #3

--- a/lib/get-client-id-postfix.js
+++ b/lib/get-client-id-postfix.js
@@ -1,0 +1,7 @@
+const os = require('node:os');
+const crypto = require('crypto');
+const package = require('../package.json');
+
+module.exports = function getClientIdPostfix() {
+  return `${package.name}@${package.version}@${os.hostname}-${crypto.randomBytes(4).toString('hex')}`;
+}

--- a/lib/realmq.js
+++ b/lib/realmq.js
@@ -10,6 +10,7 @@ const me = require('./resources/me');
 const messages = require('./resources/messages');
 const users = require('./resources/users');
 const subscriptions = require('./resources/subscriptions');
+const generateClientIdPostfix = require('./get-client-id-postfix');
 
 class RealMQ {
   static get API_RESOURCES() {
@@ -30,6 +31,7 @@ class RealMQ {
    * @param {boolean} [autoConnect]
    * @param {boolean} [autoSubscribe]
    * @param {boolean} [enableSubscriptionSyncEvents]
+   * @param {() => string} [getClientIdPostfix]
    */
   constructor(
     authToken,
@@ -38,17 +40,21 @@ class RealMQ {
       autoConnect = false,
       autoSubscribe = false,
       enableSubscriptionSyncEvents = true,
+      getClientIdPostfix = generateClientIdPostfix
     } = {}
   ) {
     this.apiClient = new ApiClient(authToken, {baseUrl: `https://api.${host}`});
 
-    RealMQ.API_RESOURCES.forEach(([name, createResouce]) => {
-      this[name] = createResouce(this.apiClient);
+    RealMQ.API_RESOURCES.forEach(([name, createResource]) => {
+      this[name] = createResource(this.apiClient);
     });
+
+    const clientIdPostfix = getClientIdPostfix();
 
     this.rtm = new RtmClient(authToken, {
       host: `rtm.${host}`,
       enableSubscriptionSyncEvents,
+      clientId: `${authToken}${clientIdPostfix ? `:${clientIdPostfix}`: ''}`
     });
 
     if (autoConnect || autoSubscribe) {


### PR DESCRIPTION
Allow for multiple rtm connections per token in the node sdk.